### PR TITLE
fix(#100): Fix duplicate plugin registration for multi-model usage

### DIFF
--- a/deploy/infer/backend.hpp
+++ b/deploy/infer/backend.hpp
@@ -76,16 +76,15 @@ private:
     void dynamicInfer(const std::vector<Image>& inputs);
     void staticInfer(const std::vector<Image>& inputs);
 
-    std::shared_ptr<nvinfer1::ICudaEngine>       engine_;         // < CUDA 引擎共享指针
-    std::unique_ptr<nvinfer1::IExecutionContext> context_;        // < 执行上下文共享指针
-    CudaGraph                                    cuda_graph_;     // < CUDA 图
-    std::unique_ptr<BaseBuffer>                  inputs_buffer_;  // < 输入缓冲区智能指针
-    BufferType                                   buffer_type_;    // < 缓冲区类型
+    std::unique_ptr<TRTManager> manager_;        // < TensorRT 管理器对象的智能指针
+    CudaGraph                   cuda_graph_;     // < CUDA 图
+    std::unique_ptr<BaseBuffer> inputs_buffer_;  // < 输入缓冲区智能指针
+    BufferType                  buffer_type_;    // < 缓冲区类型
 
-    bool zero_copy_;                                              // < 是否为零拷贝
+    bool zero_copy_;                             // < 是否为零拷贝
 
-    int input_size_;                                              // < 输入大小
-    int infer_size_;                                              // < 推理大小
+    int input_size_;                             // < 输入大小
+    int infer_size_;                             // < 推理大小
 };
 
 }  // namespace deploy


### PR DESCRIPTION
- Issue: When using multiple models simultaneously, the plugin  was being registered multiple times, causing an error.
- Fix: Added a check mechanism in the initialization logic of `TRTManager` to avoid duplicate plugin registration.
- Impact: After the fix, multiple models can be loaded simultaneously without triggering the plugin duplicate registration error.