### PR TITLE
fix: Correct pointer reference logic for `option.cuda_mem`

### DIFF
--- a/deploy/infer/backend.cpp
+++ b/deploy/infer/backend.cpp
@@ -284,7 +284,7 @@ void TrtBackend::staticInfer(const std::vector<Image>& inputs) {
             auto infer_device_ptr = static_cast<float*>(tensor_infos.front().buffer->device()) + idx * infer_size_;
 
             void* kernelParams[] = {
-                option.cuda_mem ? (void*)&inputs[idx] : (void*)&input_ptr,
+                option.cuda_mem ? (void*)&inputs[idx].ptr : (void*)&input_ptr,
                 (void*)&inputs[idx].width,
                 (void*)&inputs[idx].height,
                 (void*)&infer_device_ptr,


### PR DESCRIPTION
When `option.cuda_mem` is true, the code previously referenced the address of `inputs[idx]` directly. This has been updated to reference `inputs[idx].ptr` instead, to better align with the intended behavior.

While this fix does not cause any runtime issues (as both point to the same address), it resolves a potential logical inconsistency and makes the code clearer and more precise.