### PR TITLE
fix(#212): switch CUDA device before inference

### DIFF
--- a/modules/trtyolo/infer/backend.cpp
+++ b/modules/trtyolo/infer/backend.cpp
@@ -428,6 +428,8 @@ void TrtBackend::dynamicInfer(const std::vector<Image>& inputs) {
 }
 
 void TrtBackend::infer(const std::vector<Image>& inputs) {
+    cudaSetDevice(infer_config.device_id);  // 推理前切换设备
+
     if (dynamic) {
         dynamicInfer(inputs);
     } else {


### PR DESCRIPTION
- Ensures the current thread is bound to the target CUDA device before inference
- Prevents illegal memory access or incorrect results caused by device mismatch in multi-GPU setups