### PR TITLE
feat(trtyolo, #206): add image channel support and refactor Python bindings

### DIFF
--- a/modules/trtyolo/binding/trtyolo.cpp
+++ b/modules/trtyolo/binding/trtyolo.cpp
@@ -1,7 +1,7 @@
 /**
  * @file pybind.cpp
  * @author laugh12321 (laugh12321@vip.qq.com)
- * @brief TensorRT-YOLO的Python绑定，提供结果、选项和模型模块的包装
+ * @brief trtyolo的Python绑定，提供结果、选项和模型模块的包装
  * @date 2025-01-17
  *
  * @copyright Copyright (c) 2025 laugh12321. All Rights Reserved.
@@ -12,139 +12,202 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-#include <sstream>
+#include <cstddef>
 
 #include "infer/trtyolo.hpp"
 
 namespace py = pybind11;
 
 /**
- * @brief 绑定result.hpp文件，包括Mask、KeyPoint、Box等类。
+ * @brief 模板函数，用于将结果类绑定到Python接口，支持对单张或多张结果进行操作。
  *
- * 该模块包装了多个与结果相关的类，如Mask、KeyPoint、Box等，并提供与数据交互的方法，
- * 以及将它们转换为NumPy数组以便在Python中更容易操作的功能。
+ * 该模板函数会封装常见的结果类行为，将不同类型的结果类（如分类结果ClassifyRes、检测结果DetectRes等）
+ * 绑定到Python模块中，方便在Python环境中使用这些结果类。同时会根据不同的结果类型，
+ * 提供不同的属性访问方法，例如获取边界框坐标、分割掩码、关键点信息等。
+ *
+ * @tparam ResultType 结果类型模板参数，可传入具体的结果类（如ClassifyRes、DetectRes等）。
+ * @param m 要绑定类的pybind11模块对象，用于创建Python类。
+ * @param result_name 结果类的名称，用于在Python中标识该类。
+ */
+template <typename ResultType>
+void bind_result(py::module& m, const std::string& result_name) {
+    std::string docstring;
+    if constexpr (std::is_same_v<ResultType, trtyolo::ClassifyRes>) {
+        docstring = "A class representing classification results containing predicted classes and their confidence scores.";
+    } else if constexpr (std::is_same_v<ResultType, trtyolo::DetectRes>) {
+        docstring = "A class representing object detection results containing bounding boxes, predicted classes and their confidence scores.";
+    } else if constexpr (std::is_same_v<ResultType, trtyolo::OBBRes>) {
+        docstring = "A class representing oriented object detection results containing rotated bounding boxes, predicted classes and their confidence scores.";
+    } else if constexpr (std::is_same_v<ResultType, trtyolo::SegmentRes>) {
+        docstring = "A class representing instance segmentation results containing bounding boxes, segmentation masks, predicted classes and their confidence scores.";
+    } else if constexpr (std::is_same_v<ResultType, trtyolo::PoseRes>) {
+        docstring = "A class representing pose estimation results containing bounding boxes, keypoints, predicted classes and their confidence scores.";
+    }
+
+    py::class_<ResultType, trtyolo::BaseRes> cls(m, result_name.c_str(), docstring.c_str());
+
+    if constexpr (std::is_same_v<ResultType, trtyolo::DetectRes> ||
+                  std::is_same_v<ResultType, trtyolo::OBBRes> ||
+                  std::is_same_v<ResultType, trtyolo::SegmentRes> ||
+                  std::is_same_v<ResultType, trtyolo::PoseRes>) {
+        cls.def_property_readonly("xyxy", [](const ResultType& r) -> py::array {
+            auto* owner = new std::vector<int>;
+            owner->reserve(r.boxes.size() * 4);
+            for (const auto& b : r.boxes) {
+                const auto& arr = b.xyxy();
+                owner->insert(owner->end(), arr.begin(), arr.end());
+            }
+
+            return py::array(
+                py::buffer_info(
+                    owner->data(),
+                    sizeof(int),
+                    py::format_descriptor<int>::format(),
+                    2,
+                    std::vector<size_t>{r.boxes.size(), 4},
+                    std::vector<size_t>{sizeof(int) * 4, sizeof(int)}),
+                py::cast(owner)); },
+                                  "An array of shape (n, 4) containing the bounding boxes "
+                                  "coordinates in format [x1, y1, x2, y2].");
+
+        if constexpr (std::is_same_v<ResultType, trtyolo::OBBRes>) {
+            cls.def_property_readonly("xyxyxyxy", [](const ResultType& r) -> py::array {
+                auto* owner = new std::vector<int>;
+                owner->reserve(r.boxes.size() * 8);
+                for (const auto& b : r.boxes) {
+                    const std::array<int,8>& arr = b.xyxyxyxy();
+                    owner->insert(owner->end(), arr.begin(), arr.end());
+                }
+
+                return py::array(
+                    py::buffer_info(
+                        owner->data(),
+                        sizeof(int),
+                        py::format_descriptor<int>::format(),
+                        3,
+                        std::vector<size_t>{r.boxes.size(), 4, 2},
+                        std::vector<size_t>{sizeof(int) * 8, sizeof(int) * 2, sizeof(int)}),
+                    py::cast(owner)); },
+                                      "An array of shape (n, 4, 2) containing the bounding boxes "
+                                      "coordinates in format [[x1, y1], [x2, y2], [x3, y3], [x4, y4]].");
+        }
+    }
+
+    if constexpr (std::is_same_v<ResultType, trtyolo::SegmentRes>) {
+        cls.def_property_readonly("masks", [](const ResultType& r) -> py::array {
+            if (r.masks.empty()) return py::array_t<float>();
+            size_t n = r.masks.size();
+            size_t h = r.masks[0].height;
+            size_t w = r.masks[0].width;
+
+            auto* owner = new std::vector<float>;
+            owner->reserve(n * h * w);
+            for (const auto& mask : r.masks) owner->insert(owner->end(), mask.data.begin(), mask.data.end());
+            return py::array(
+                py::buffer_info(
+                    owner->data(),
+                    sizeof(float),
+                    py::format_descriptor<float>::format(),
+                    3,
+                    {n, h, w},
+                    {sizeof(float) * h * w, sizeof(float) * w, sizeof(float)}),
+                py::cast(owner)); }, "An array of shape (n, H, W) containing the segmentation masks.");
+    }
+
+    if constexpr (std::is_same_v<ResultType, trtyolo::PoseRes>) {
+        cls.def_property_readonly("kpts", [](const ResultType& r) -> py::array {
+            size_t n = r.kpts.size();
+            size_t m = r.kpts.empty() ? 0 : r.kpts[0].size();
+            size_t c = r.kpts.empty() || r.kpts[0].empty() ? 0 : r.kpts[0][0].conf ? 3 : 2;
+
+            py::array_t<float> array({n, m, c});
+            auto               rptr = array.mutable_unchecked<3>();
+
+            for (size_t i = 0; i < n; ++i) {
+                for (size_t j = 0; j < m; ++j) {
+                    rptr(i, j, 0) = r.kpts[i][j].x;
+                    rptr(i, j, 1) = r.kpts[i][j].y;
+                    if (c == 3) rptr(i, j, 2) = r.kpts[i][j].conf.value_or(0.0f);
+                }
+            }
+            return array; },
+                                  "An array of shape (n, m, c) containing n detected objects, "
+                                  "each composed of m equally-sized sets of keypoints and confidence scores of each keypoint. "
+                                  "Where each point is [x, y] if c is 2, or [x, y, conf] if c is 3.");
+    }
+};
+
+/**
+ * @brief 为trtyolo结果类创建Python绑定
+ *
+ * 该函数负责将trtyolo中的结果相关C++类绑定到Python，使其可以在Python中使用。
+ * 主要功能包括：
+ * 1. 绑定基础结果类BaseRes，提供通用属性和方法
+ * 2. 将C++数据结构转换为NumPy数组，便于在Python中进行数据分析和可视化
+ * 3. 注册多种专门的结果类型，每种类型对应不同的计算机视觉任务
+ *
+ * 绑定的结果类型包括：
+ * - ClassifyRes: 分类结果
+ * - DetectRes: 目标检测结果(矩形框)
+ * - OBBRes: 旋转目标检测结果
+ * - SegmentRes: 实例分割结果(带掩码)
+ * - PoseRes: 人体姿态估计结果(带关键点)
  */
 void binding_result_module(py::module& m) {
-    m.doc() = "Result module of TensorRT-YOLO, including Mask, KeyPoint, Box, and other result-related classes.";
+    m.doc() = "Result module of trtyolo, providing Python bindings for various computer vision result types including classification, object detection, rotated object detection, instance segmentation and pose estimation.";
 
-    py::class_<trtyolo::Mask>(m, "Mask", "A class representing a mask with height, width, and associated data.")
-        .def(py::init<int, int>(), py::arg("width"), py::arg("height"))
-        .def_readwrite("data", &trtyolo::Mask::data, "The mask data as a list of uint8 values.")
-        .def_readwrite("width", &trtyolo::Mask::width, "The width of the mask.")
-        .def_readwrite("height", &trtyolo::Mask::height, "The height of the mask.")
-        .def("__str__", [](const trtyolo::Mask& mask) {
-            std::ostringstream oss;
-            oss << mask;
-            return oss.str();
-        })
-        .def("to_numpy", [](const trtyolo::Mask& mask) {
-            // 将Mask数据转换为形状为(height, width)的NumPy数组
-            py::array_t<uint8_t> np_array({mask.height, mask.width});
-            auto                 ptr = np_array.mutable_data();
-            std::copy(mask.data.begin(), mask.data.end(), ptr);
-            return np_array;
-        });
+    // 基础结果类，所有结果类型的基类，提供通用功能和属性
+    py::class_<trtyolo::BaseRes>(m, "BaseRes", "A base class for all result types, providing common properties like number of results, class IDs, and confidence scores.")
+        // 允许使用Python的len()函数获取结果数量
+        .def("__len__", [](const trtyolo::BaseRes& r) { return r.num; }, "Return the number of detected objects via Python's len() function.")
+        // 检测对象的类别ID数组
+        .def_property_readonly("class_id", [](const trtyolo::BaseRes& r) -> py::array { return py::array(
+                                                                                            py::buffer_info(
+                                                                                                const_cast<int*>(r.classes.data()),
+                                                                                                sizeof(int),
+                                                                                                py::format_descriptor<int>::format(),
+                                                                                                1,
+                                                                                                {r.classes.size()},
+                                                                                                {sizeof(int)})); }, "An array of shape (n,) containing the class IDs of the detections.")
+        // 检测对象的置信度分数数组
+        .def_property_readonly("confidence", [](const trtyolo::BaseRes& r) -> py::array { return py::array(
+                                                                                              py::buffer_info(
+                                                                                                  const_cast<float*>(r.scores.data()),
+                                                                                                  sizeof(float),
+                                                                                                  py::format_descriptor<float>::format(),
+                                                                                                  1,
+                                                                                                  {r.scores.size()},
+                                                                                                  {sizeof(float)})); }, "An array of shape (n,) containing the confidence scores of the detections.");
 
-    py::class_<trtyolo::KeyPoint>(m, "KeyPoint", "A class representing a keypoint with (x, y) coordinates and confidence score.")
-        .def_readwrite("x", &trtyolo::KeyPoint::x, "The x-coordinate of the keypoint.")
-        .def_readwrite("y", &trtyolo::KeyPoint::y, "The y-coordinate of the keypoint.")
-        .def_readwrite("conf", &trtyolo::KeyPoint::conf, "The confidence score for the keypoint.")
-        .def("__str__", [](const trtyolo::KeyPoint& kpt) {
-            std::ostringstream oss;
-            oss << kpt;
-            return oss.str();
-        });
-
-    py::class_<trtyolo::Box>(m, "Box", "A class representing a bounding box with (left, top, right, bottom) coordinates.")
-        .def_readwrite("left", &trtyolo::Box::left, "The left coordinate of the bounding box.")
-        .def_readwrite("top", &trtyolo::Box::top, "The top coordinate of the bounding box.")
-        .def_readwrite("right", &trtyolo::Box::right, "The right coordinate of the bounding box.")
-        .def_readwrite("bottom", &trtyolo::Box::bottom, "The bottom coordinate of the bounding box.")
-        .def("__str__", [](const trtyolo::Box& box) {
-            std::ostringstream oss;
-            oss << box;
-            return oss.str();
-        });
-
-    py::class_<trtyolo::RotatedBox, trtyolo::Box>(m, "RotatedBox", "A class representing a rotated bounding box with an additional rotation angle (theta).")
-        .def_readwrite("theta", &trtyolo::RotatedBox::theta, "The rotation angle of the bounding box.")
-        .def("__str__", [](const trtyolo::RotatedBox& rbox) {
-            std::ostringstream oss;
-            oss << rbox;
-            return oss.str();
-        });
-
-    py::class_<trtyolo::ClassifyRes>(m, "ClassifyRes", "A class representing classification results, including number of results, classes, and their confidence scores.")
-        .def_readwrite("num", &trtyolo::ClassifyRes::num, "The number of classification results.")
-        .def_readwrite("classes", &trtyolo::ClassifyRes::classes, "List of class IDs for classification results.")
-        .def_readwrite("scores", &trtyolo::ClassifyRes::scores, "List of confidence scores for each class.")
-        .def("__str__", [](const trtyolo::ClassifyRes& res) {
-            std::ostringstream oss;
-            oss << res;
-            return oss.str();
-        });
-
-    py::class_<trtyolo::DetectRes>(m, "DetectRes", "A class representing detection results, including the number of detections, classes, scores, and bounding boxes.")
-        .def_readwrite("num", &trtyolo::DetectRes::num, "The number of detection results.")
-        .def_readwrite("classes", &trtyolo::DetectRes::classes, "List of class IDs for detected objects.")
-        .def_readwrite("scores", &trtyolo::DetectRes::scores, "List of confidence scores for each detection.")
-        .def_readwrite("boxes", &trtyolo::DetectRes::boxes, "List of bounding boxes for detected objects.")
-        .def("__str__", [](const trtyolo::DetectRes& res) {
-            std::ostringstream oss;
-            oss << res;
-            return oss.str();
-        });
-
-    py::class_<trtyolo::OBBRes>(m, "OBBRes", "A class representing the results of rotated bounding box detection.")
-        .def_readwrite("num", &trtyolo::OBBRes::num, "The number of OBB detection results.")
-        .def_readwrite("classes", &trtyolo::OBBRes::classes, "List of class IDs for rotated bounding boxes.")
-        .def_readwrite("scores", &trtyolo::OBBRes::scores, "List of confidence scores for rotated bounding boxes.")
-        .def_readwrite("boxes", &trtyolo::OBBRes::boxes, "List of rotated bounding boxes for detected objects.")
-        .def("__str__", [](const trtyolo::OBBRes& res) {
-            std::ostringstream oss;
-            oss << res;
-            return oss.str();
-        });
-
-    py::class_<trtyolo::SegmentRes>(m, "SegmentRes", "A class representing segmentation results, including boxes and masks for detected objects.")
-        .def_readwrite("num", &trtyolo::SegmentRes::num, "The number of segmentation results.")
-        .def_readwrite("classes", &trtyolo::SegmentRes::classes, "List of class IDs for segmented objects.")
-        .def_readwrite("scores", &trtyolo::SegmentRes::scores, "List of confidence scores for each segmentation.")
-        .def_readwrite("boxes", &trtyolo::SegmentRes::boxes, "List of bounding boxes for segmented objects.")
-        .def_readwrite("masks", &trtyolo::SegmentRes::masks, "List of masks for segmented objects.")
-        .def("__str__", [](const trtyolo::SegmentRes& res) {
-            std::ostringstream oss;
-            oss << res;
-            return oss.str();
-        });
-
-    py::class_<trtyolo::PoseRes>(m, "PoseRes", "A class representing pose detection results, including keypoints, scores, and bounding boxes.")
-        .def_readwrite("num", &trtyolo::PoseRes::num, "The number of pose detection results.")
-        .def_readwrite("classes", &trtyolo::PoseRes::classes, "List of class IDs for pose detection.")
-        .def_readwrite("scores", &trtyolo::PoseRes::scores, "List of confidence scores for each pose detection.")
-        .def_readwrite("boxes", &trtyolo::PoseRes::boxes, "List of bounding boxes for pose detections.")
-        .def_readwrite("kpts", &trtyolo::PoseRes::kpts, "List of keypoints for pose detections.")
-        .def("__str__", [](const trtyolo::PoseRes& res) {
-            std::ostringstream oss;
-            oss << res;
-            return oss.str();
-        });
+    // 绑定各种专门的结果类型
+    bind_result<trtyolo::ClassifyRes>(m, "ClassifyRes");  // 分类结果
+    bind_result<trtyolo::DetectRes>(m, "DetectRes");      // 目标检测结果(矩形框)
+    bind_result<trtyolo::OBBRes>(m, "OBBRes");            // 旋转目标检测结果
+    bind_result<trtyolo::SegmentRes>(m, "SegmentRes");    // 实例分割结果(带掩码)
+    bind_result<trtyolo::PoseRes>(m, "PoseRes");          // 人体姿态估计结果(带关键点)
 }
 
 /**
- * @brief 绑定option.hpp文件，允许用户设置各种推理选项。
+ * @brief 为trtyolo推理选项创建Python绑定
  *
- * 该模块提供了InferOption类的绑定，可以配置各种推理参数，如设备设置、内存选项和图像预处理等。
+ * 该函数负责将trtyolo中的InferOption类绑定到Python，提供灵活的推理配置选项。
+ * 通过这个模块，用户可以定制推理过程中的各项参数，包括但不限于：
+ * 1. 设备设置：选择GPU设备
+ * 2. 性能监控：启用性能分析
+ * 3. 图像预处理：配置色彩转换、边界值、归一化参数等
+ * 4. 模型输入尺寸：设置输入图像的高度和宽度
+ *
+ * 所有配置选项将直接影响推理性能和结果质量，用户可以根据具体需求进行调整。
  */
 void binding_option_module(py::module& m) {
-    m.doc() = "Option module of TensorRT-YOLO, providing options to configure inference settings.";
+    m.doc() = "Option module of trtyolo, providing comprehensive configuration options for inference including device selection, performance monitoring, and image preprocessing.";
 
-    py::class_<trtyolo::InferOption>(m, "InferOption", "A class to configure inference options, including device settings, memory options, and image preprocessing.")
+    py::class_<trtyolo::InferOption>(m, "InferOption", "A class to configure advanced inference options for trtyolo models, controlling device selection, performance monitoring, and image preprocessing.")
         .def(py::init<>())
         .def("set_device_id", &trtyolo::InferOption::setDeviceId, "Set the device ID (GPU) for inference.")
-        .def("enable_cuda_memory", &trtyolo::InferOption::enableCudaMem, "Inference data already in CUDA memory.")
-        .def("enable_managed_memory", &trtyolo::InferOption::enableManagedMemory, "Enable managed memory for inference.")
-        .def("enable_performance_report", &trtyolo::InferOption::enablePerformanceReport, "Enable performance report for inference.")
+        // .def("enable_cuda_memory", &trtyolo::InferOption::enableCudaMem, "Inference data already in CUDA memory.")
+        // .def("enable_managed_memory", &trtyolo::InferOption::enableManagedMemory, "Enable managed memory for inference.")
+        .def("enable_profile", &trtyolo::InferOption::enablePerformanceReport, "Enable performance profile for inference.")
         .def("enable_swap_rb", &trtyolo::InferOption::enableSwapRB, "Enable RGB-to-BGR swap for image input.")
         .def("set_border_value", &trtyolo::InferOption::setBorderValue, "Set border value for image resizing (used for padding).")
         .def("set_normalize_params", &trtyolo::InferOption::setNormalizeParams, "Set normalization parameters for image preprocessing.")
@@ -154,64 +217,73 @@ void binding_option_module(py::module& m) {
 /**
  * @brief 将NumPy数组转换为trtyolo::Image对象。
  *
- * 此函数用于将一个3D的NumPy数组（高、宽、通道）转换为trtyolo::Image对象，用于推理任务。
+ * 此函数会把一个形状为(height, width, channels)、数据类型为uint8的3D NumPy数组，
+ * 转换为trtyolo::Image对象，该对象可用于后续的推理任务。
+ * 函数会检查输入数组的维度和通道数，若输入数组不是3维，或者第三维通道数不为3，
+ * 则抛出 std::invalid_argument 异常。
  *
- * @param pyarray 一个形状为(height, width, channels)且数据类型为uint8的NumPy数组。
- * @return trtyolo::Image 一个可用于推理的图像对象。
- * @throws std::invalid_argument 如果输入数组不是3维，或者数据类型不是uint8，则抛出异常。
+ * @param src 输入的NumPy数组，要求形状为(height, width, channels)，数据类型为uint8。
+ * @return trtyolo::Image 转换后的可用于推理的图像对象。
+ * @throws std::invalid_argument 当输入数组不是3维，或者第三维通道数不为3时抛出此异常。
  */
-trtyolo::Image PyArray2Image(py::array& pyarray) {
-    if (pyarray.ndim() != 3) {
+trtyolo::Image PyArray2Image(const py::array_t<uint8_t>& src) {
+    py::buffer_info buf = src.request();
+    if (buf.ndim != 3 || buf.shape[2] != 3) {
         throw std::invalid_argument("Require rank of array to be 3 with HWC format while converting it to trtyolo::Image.");
     }
-    py::buffer_info buf_info = pyarray.request();
-    int             height   = buf_info.shape[0];
-    int             width    = buf_info.shape[1];
-    void*           data     = buf_info.ptr;
-    if (buf_info.format != py::format_descriptor<uint8_t>::format()) {
-        throw std::invalid_argument("Expected array data type is uint8.");
-    }
-    return trtyolo::Image(data, width, height);
+
+    return trtyolo::Image(buf.ptr, buf.shape[1], buf.shape[0], buf.shape[2], buf.strides[0]);
 }
 
 /**
- * @brief 模板函数，绑定一个模型类，允许对单张或多张图像进行预测。
+ * @brief 为trtyolo模型类创建Python绑定的模板函数
  *
- * 该模板函数包装了常见的模型行为，便于将各种模型（如ClassifyModel、DetectModel）添加到Python接口。
+ * 该模板函数提供了一个统一的方式来将各种trtyolo模型类绑定到Python接口，
+ * 封装了模型的通用功能，如初始化、预测、克隆和性能分析等。通过这个模板，
+ * 可以轻松地为不同类型的模型（如分类、检测、分割等）创建一致的Python API。
  *
- * @tparam ModelType 模型类型（如ClassifyModel、DetectModel等）。
- * @param m 要绑定类的pybind11模块。
- * @param model_name 模型类的名称。
+ * @tparam ModelType 模型类型模板参数，可以是ClassifyModel、DetectModel、OBBModel等
+ * @param m 目标pybind11模块，用于注册Python类
+ * @param model_name Python中可见的模型类名称
  */
 template <typename ModelType>
 void bind_model(py::module& m, const std::string& model_name) {
-    py::class_<ModelType, std::unique_ptr<ModelType>>(m, model_name.c_str(), "A model class for performing inference tasks.")
-        .def(py::init<const std::string&, const trtyolo::InferOption&>(), "Initialize the model with a model file and inference options.")
-        .def("clone", &ModelType::clone, "Clone the model instance.")
+    py::class_<ModelType, std::unique_ptr<ModelType>>(m, model_name.c_str(),
+                                                      "A trtyolo model class for performing computer vision inference tasks with TensorRT acceleration.")
+        .def(py::init<const std::string&, const trtyolo::InferOption&>(),
+             "Initialize the model with a TensorRT engine file path and inference configuration options.")
+        .def("clone", &ModelType::clone,
+             "Create a clone of the current model instance with the same configuration (shared engine, create a new context).")
         .def(
             "predict", [](ModelType& self, py::array& input) {
                 return self.predict(PyArray2Image(input));
             },
-            "Predict the result from a single image (HWC format numpy array).")
+            "Run inference on a single image represented as a HWC-format numpy array (height, width, channels).")
         .def("predict", [](ModelType& self, std::vector<py::array>& inputs) {
                 std::vector<trtyolo::Image> images;
-                std::transform(inputs.begin(), inputs.end(), std::back_inserter(images), [](py::array& input) {
-                    return PyArray2Image(input);
-                });
-                return self.predict(images); }, "Predict the results from a list of images (list of HWC format numpy arrays).")
-        .def("performance_report", [](ModelType& self) {
+                images.reserve(inputs.size());
+                for (auto& arr : inputs) images.push_back(PyArray2Image(arr));
+                return self.predict(images); }, "Run batch inference on a list of images, each represented as a HWC-format numpy array.")
+        .def("profile", [](ModelType& self) {
             auto report = self.performanceReport();
-            return std::make_tuple(py::str(std::get<0>(report)), py::str(std::get<1>(report)), py::str(std::get<2>(report))); }, "Get the performance report of the model.")
-        .def("batch", &ModelType::batch, "Get the batch size of the model.");
+            return std::make_tuple(py::str(std::get<0>(report)), py::str(std::get<1>(report)), py::str(std::get<2>(report))); }, "Get the performance profile of the model as a tuple of (preprocess_time, inference_time, postprocess_time).")
+        .def_property_readonly("batch", &ModelType::batch, "Get the maximum batch size supported by the model for batch inference.");
 }
 
 /**
- * @brief 绑定模型模块，包括分类、检测等各种模型类。
+ * @brief 绑定模型模块，实现所有模型类到Python的映射。
  *
- * 该模块绑定了所有模型类，使它们可以在Python中进行推理任务。
+ * 该函数负责将trtyolo命名空间下的各类模型（分类、检测、旋转框检测、实例分割、姿态估计）
+ * 绑定到Python模块中，使这些模型可以在Python环境中被实例化和调用，
+ * 执行相应的计算机视觉推理任务。每个模型类都通过bind_model模板函数进行统一绑定，
+ * 确保接口一致性和功能完整性。
+ *
+ * @param m Python模块对象，用于注册模型类
  */
 void binding_model_module(py::module& m) {
-    m.doc() = "Python bindings for model.hpp, including classes like ClassifyModel, DetectModel, OBBModel, etc.";
+    m.doc() =
+        "Model module of trtyolo, providing TensorRT-accelerated inference for computer vision tasks, "
+        "including ClassifyModel, DetectModel, OBBModel, SegmentModel, and PoseModel.";
 
     bind_model<trtyolo::ClassifyModel>(m, "ClassifyModel");
     bind_model<trtyolo::DetectModel>(m, "DetectModel");
@@ -221,19 +293,25 @@ void binding_model_module(py::module& m) {
 }
 
 /**
- * @brief TensorRT-YOLO的Python绑定主模块。
+ * @brief trtyolo Python绑定主模块。
  *
- * 该模块包括结果、选项和模型子模块的绑定，允许用户轻松处理推理结果、配置选项，并执行分类、检测等任务。
+ * 此模块借助Pybind11创建TensorRT-YOLO的Python绑定接口，
+ * 包含三个子模块：
+ * - result：封装推理结果类，可将结果转换为NumPy数组以便在Python中使用；
+ * - option：提供推理选项配置类，可设置设备、内存、图像预处理等参数；
+ * - model：绑定各类模型，支持单张或批量图像的推理任务。
+ * 用户可通过该模块在Python环境中轻松处理推理结果、配置推理选项，
+ * 并执行分类、检测、目标旋转框检测、实例分割和关键点检测等任务。
  */
 PYBIND11_MODULE(py_trtyolo, m) {
-    m.doc() = "TensorRT-YOLO Python bindings using Pybind11";
+    m.doc() = "Python bindings for trtyolo, providing TensorRT-accelerated inference for computer vision tasks.";
 
-    py::module result_module = m.def_submodule("result", "Result module of TensorRT-YOLO.");
+    py::module result_module = m.def_submodule("result");
     binding_result_module(result_module);
 
-    py::module option_module = m.def_submodule("option", "Option module of TensorRT-YOLO.");
+    py::module option_module = m.def_submodule("option");
     binding_option_module(option_module);
 
-    py::module model_module = m.def_submodule("model", "Model module of TensorRT-YOLO.");
+    py::module model_module = m.def_submodule("model");
     binding_model_module(model_module);
 }

--- a/modules/trtyolo/infer/trtyolo.cpp
+++ b/modules/trtyolo/infer/trtyolo.cpp
@@ -19,19 +19,29 @@
 
 namespace trtyolo {
 
-Image::Image(void* data, int width, int height) : ptr(data), width(width), height(height), pitch(width * sizeof(uint8_t) * 3) {
+Image::Image(void* data, int width, int height) : ptr(data), width(width), height(height), channels(3), pitch(width * sizeof(uint8_t) * 3) {
     if (width <= 0 || height <= 0) {
         throw std::invalid_argument(MAKE_ERROR_MESSAGE("Image: width and height must be positive"));
     }
 }
 
 Image::Image(void* data, int width, int height, size_t pitch)
-    : ptr(data), width(width), height(height), pitch(pitch) {
-    if (width <= 0 || height <= 0) {
-        throw std::invalid_argument(MAKE_ERROR_MESSAGE("Image: width and height must be positive"));
+    : ptr(data), width(width), height(height), channels(3), pitch(pitch) {
+    if (width <= 0 || height <= 0 || channels <= 0) {
+        throw std::invalid_argument(MAKE_ERROR_MESSAGE("Image: width, height and channels must be positive"));
     }
-    if (pitch < static_cast<size_t>(width * sizeof(uint8_t) * 3)) {
-        throw std::invalid_argument(MAKE_ERROR_MESSAGE("Image: pitch must >= width * 3"));
+    if (pitch < static_cast<size_t>(width * sizeof(uint8_t) * channels)) {
+        throw std::invalid_argument(MAKE_ERROR_MESSAGE("Image: pitch must >= width * channels"));
+    }
+}
+
+Image::Image(void* data, int width, int height, int channels, size_t pitch)
+    : ptr(data), width(width), height(height), channels(channels), pitch(pitch) {
+    if (width <= 0 || height <= 0 || channels <= 0) {
+        throw std::invalid_argument(MAKE_ERROR_MESSAGE("Image: width, height and channels must be positive"));
+    }
+    if (pitch < static_cast<size_t>(width * sizeof(uint8_t) * channels)) {
+        throw std::invalid_argument(MAKE_ERROR_MESSAGE("Image: pitch must >= width * channels"));
     }
 }
 

--- a/modules/trtyolo/infer/trtyolo.hpp
+++ b/modules/trtyolo/infer/trtyolo.hpp
@@ -31,10 +31,11 @@ class BaseModel;  // 前向声明 BaseModel 模板类
  * @brief 图像结构体，用于存储图像数据及其尺寸信息
  */
 struct TRTYOLOAPI Image {
-    void*  ptr;         // < 图像数据指针
-    int    width  = 0;  // < 图像宽度（像素数）
-    int    height = 0;  // < 图像高度（像素数）
-    size_t pitch  = 0;  // < 图像数据行距（字节数，包括可能的 padding）
+    void*  ptr;           // < 图像数据指针
+    int    width    = 0;  // < 图像宽度（像素数）
+    int    height   = 0;  // < 图像高度（像素数）
+    int    channels = 0;  // < 图像通道数
+    size_t pitch    = 0;  // < 图像数据行距（字节数，包括可能的 padding）
 
     /**
      * @brief 构造函数（紧密排列，无 padding）
@@ -54,9 +55,20 @@ struct TRTYOLOAPI Image {
      */
     Image(void* data, int width, int height, size_t pitch);
 
+    /**
+     * @brief 构造函数（带 channels, pitch）
+     * @param data 图像数据指针
+     * @param width 图像宽度（像素数）
+     * @param height 图像高度（像素数）
+     * @param channels 图像通道数
+     * @param pitch 每行的字节数（包括可能的 padding）
+     */
+    Image(void* data, int width, int height, int channels, size_t pitch);
+
     friend std::ostream& operator<<(std::ostream& os, const Image& img) {
         os << "Image(width=" << img.width
            << ", height=" << img.height
+           << ", channels=" << img.channels
            << ", pitch=" << img.pitch
            << ", ptr=" << img.ptr << ")";
         return os;


### PR DESCRIPTION
Refactor the Image struct to support image channels and optimize the Python binding implementation:
1. Add a channels field to the Image struct
2. Introduce a constructor with a channels parameter
3. Refactor the Python binding code to simplify result class binding using templates
4. Optimize performance monitoring and batch processing interface naming
5. Improve documentation comments and error message prompts