### PR TITLE
fix(#289): check TensorRT MSVC lib file instead of dll

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ endif()
 
 # 定义 TensorRT 库的版本选择
 set(TRT_LIB_DIR "${TRT_PATH}/lib")
-if(MSVC AND EXISTS "${TRT_LIB_DIR}/nvinfer_10.dll")
+if(MSVC AND EXISTS "${TRT_LIB_DIR}/nvinfer_10.lib")
     set(TRT_LIBS nvinfer_10 nvinfer_plugin_10 nvonnxparser_10)
 else()
     set(TRT_LIBS nvinfer nvinfer_plugin nvonnxparser)


### PR DESCRIPTION
MSVC now detects nvinfer_10.lib in the TensorRT lib dir, ensuring the correct libraries are selected for linking.

## Summary by Sourcery

Bug Fixes:
- Ensure MSVC builds correctly detect and link against TensorRT v10 libraries by checking for the nvinfer_10.lib file in the TensorRT lib directory instead of the DLL.