### PR TITLE
docs: sync example READMEs with model convert workflow

### DIFF
--- a/examples/VideoPipe/README.en.md
+++ b/examples/VideoPipe/README.en.md
@@ -8,22 +8,23 @@ This example uses the YOLO11n model to demonstrate how to integrate the TensorRT
 
 Please download the required `yolo11n.pt` model file and test video through the provided link, and save both to the `workspace` folder.
 
-## Model Export
+## Model Convert
 
 > [!IMPORTANT]
 >
-> Use the [`trtyolo-export`](https://github.com/laugh12321/TensorRT-YOLO/tree/export) tool package that comes with the project to export the ONNX model suitable for inference in this project and build it into a TensorRT engine.
+> Please first export the model weights to ONNX, then use the bundled [`trtyolo-export`](https://github.com/laugh12321/trtyolo-export) tool to convert the ONNX model into TensorRT-YOLO compatible outputs and build it into a TensorRT engine.
 
-Use the following command to export the ONNX format with the [EfficientNMS](https://github.com/NVIDIA/TensorRT/tree/main/plugin/efficientNMSPlugin) plugin:
+Use the following commands to export ONNX first and then convert it into the structure required by this project. The converted ONNX will automatically integrate the [EfficientNMS](https://github.com/NVIDIA/TensorRT/tree/main/plugin/efficientNMSPlugin) plugin:
 
 ```bash
-trtyolo export -w workspace/yolo11n.pt -v yolo11 -o workspace -b 2 -s
+yolo export model=workspace/yolo11n.pt format=onnx batch=2
+trtyolo-export -i workspace/yolo11n.onnx -o workspace/yolo11n-trtyolo.onnx -s
 ```
 
-After running the above command, a `yolo11n.onnx` file with a `batch_size` of 2 will be generated in the `models` folder. Next, use the `trtexec` tool to convert the ONNX file to a TensorRT engine (fp16):
+After running the commands above, the `workspace` folder will contain the original ONNX file `yolo11n.onnx` and the converted file `yolo11n-trtyolo.onnx`. Next, use `trtexec` to build a TensorRT engine from the converted ONNX file (fp16):
 
 ```bash
-trtexec --onnx=workspace/yolo11n.onnx --saveEngine=workspace/yolo11n.engine --fp16
+trtexec --onnx=workspace/yolo11n-trtyolo.onnx --saveEngine=workspace/yolo11n.engine --fp16
 ```
 
 ## Project Execution

--- a/examples/VideoPipe/README.md
+++ b/examples/VideoPipe/README.md
@@ -6,24 +6,25 @@
 
 [yolo11n.pt](https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n.pt)，[demo0.mp4](https://www.ilanzou.com/s/yhUyq8f3)，[demo1.mp4](https://www.ilanzou.com/s/aIhyq8ET)
 
-请通过提供的链接下载所需的 `yolo11n.pt` 模型文件和测试视频，并均保存至 `worksapce` 文件夹。
+请通过提供的链接下载所需的 `yolo11n.pt` 模型文件和测试视频，并均保存至 `workspace` 文件夹。
 
-## 模型导出
+## 模型转换
 
 > [!IMPORTANT]
 >
-> 使用项目配套的 [`trtyolo-export`](https://github.com/laugh12321/TensorRT-YOLO/tree/export) 工具包，导出适用于该项目推理的 ONNX 模型并构建为 TensorRT 引擎。
+> 请先将模型权重导出为 ONNX，再使用项目配套的 [`trtyolo-export`](https://github.com/laugh12321/trtyolo-export) 工具包，将 ONNX 模型转换为兼容 TensorRT-YOLO 推理的输出结构并构建为 TensorRT 引擎。
 
-使用以下命令导出带 [EfficientNMS](https://github.com/NVIDIA/TensorRT/tree/main/plugin/efficientNMSPlugin) 插件的 ONNX 格式：
+使用以下命令先导出 ONNX，再转换为适用于该项目推理的模型结构。转换后的 ONNX 会自动集成 [EfficientNMS](https://github.com/NVIDIA/TensorRT/tree/main/plugin/efficientNMSPlugin) 插件：
 
 ```bash
-trtyolo export -w workspace/yolo11n.pt -v yolo11 -o workspace -b 2 -s
+yolo export model=workspace/yolo11n.pt format=onnx batch=2
+trtyolo-export -i workspace/yolo11n.onnx -o workspace/yolo11n-trtyolo.onnx -s
 ```
 
-运行上述命令后，`models` 文件夹中将生成一个 `batch_size` 为 2 的 `yolo11n.onnx` 文件。接下来，使用 `trtexec` 工具将 ONNX 文件转换为 TensorRT 引擎（fp16）：
+运行上述命令后，`workspace` 文件夹中将依次生成原始 ONNX 文件 `yolo11n.onnx` 和转换后的 `yolo11n-trtyolo.onnx`。接下来，使用 `trtexec` 工具将转换后的 ONNX 文件构建为 TensorRT 引擎（fp16）：
 
 ```bash
-trtexec --onnx=workspace/yolo11n.onnx --saveEngine=workspace/yolo11n.engine --fp16
+trtexec --onnx=workspace/yolo11n-trtyolo.onnx --saveEngine=workspace/yolo11n.engine --fp16
 ```
 
 ## 项目运行

--- a/examples/classify/README.en.md
+++ b/examples/classify/README.en.md
@@ -8,22 +8,23 @@ This example uses the yolo11n-cls model to demonstrate how to perform Image Clas
 
 Please download the required `yolo11n-cls.pt` model file and test images through the provided link, and save the model file to the `models` folder, and place the extracted test images into the `images` folder after unzipping.
 
-## Model Export
+## Model Convert
 
 > [!IMPORTANT]
 >
-> Use the [`trtyolo-export`](https://github.com/laugh12321/TensorRT-YOLO/tree/export) tool package that comes with the project to export the ONNX model suitable for inference in this project and build it into a TensorRT engine.
+> Please first export the model weights to ONNX, then use the bundled [`trtyolo-export`](https://github.com/laugh12321/trtyolo-export) tool to convert the ONNX model into TensorRT-YOLO compatible outputs and build it into a TensorRT engine.
 
-Use the following command to export the ONNX format model:
+Use the following commands to export ONNX first and then convert it into the structure required by this project:
 
 ```bash
-trtyolo export -w models/yolo11n-cls.pt -v yolo11 -o models --imgsz 224 -s
+yolo export model=models/yolo11n-cls.pt format=onnx imgsz=224 batch=1
+trtyolo-export -i models/yolo11n-cls.onnx -o models/yolo11n-cls-trtyolo.onnx -s
 ```
 
-After running the above command, a `yolo11n-cls.onnx` file with a `batch_size` of 1 will be generated in the `models` folder. Next, use the `trtexec` tool to convert the ONNX file to a TensorRT engine (fp16):
+After running the commands above, the `models` folder will contain the original ONNX file `yolo11n-cls.onnx` and the converted file `yolo11n-cls-trtyolo.onnx`. Next, use `trtexec` to build a TensorRT engine from the converted ONNX file (fp16):
 
 ```bash
-trtexec --onnx=models/yolo11n-cls.onnx --saveEngine=models/yolo11n-cls.engine --fp16
+trtexec --onnx=models/yolo11n-cls-trtyolo.onnx --saveEngine=models/yolo11n-cls.engine --fp16
 ```
 
 ## Model Inference

--- a/examples/classify/README.md
+++ b/examples/classify/README.md
@@ -8,22 +8,23 @@
 
 请通过提供的链接下载所需的 `yolo11n-cls.pt` 模型文件和测试图片，并将模型文件保存至 `models` 文件夹，测试图片解压后存放至 `images` 文件夹。
 
-## 模型导出
+## 模型转换
 
 > [!IMPORTANT]
 >
-> 使用项目配套的 [`trtyolo-export`](https://github.com/laugh12321/TensorRT-YOLO/tree/export) 工具包，导出适用于该项目推理的 ONNX 模型并构建为 TensorRT 引擎。
+> 请先将模型权重导出为 ONNX，再使用项目配套的 [`trtyolo-export`](https://github.com/laugh12321/trtyolo-export) 工具包，将 ONNX 模型转换为兼容 TensorRT-YOLO 推理的输出结构并构建为 TensorRT 引擎。
 
-使用以下命令导出 ONNX 格式模型：
+使用以下命令先导出 ONNX，再转换为适用于该项目推理的模型结构：
 
 ```bash
-trtyolo export -w models/yolo11n-cls.pt -v yolo11 -o models --imgsz 224 -s
+yolo export model=models/yolo11n-cls.pt format=onnx imgsz=224 batch=1
+trtyolo-export -i models/yolo11n-cls.onnx -o models/yolo11n-cls-trtyolo.onnx -s
 ```
 
-运行上述命令后，`models` 文件夹中将生成一个 `batch_size` 为 1 的 `yolo11n-cls.onnx` 文件。接下来，使用 `trtexec` 工具将 ONNX 文件转换为 TensorRT 引擎（fp16）：
+运行上述命令后，`models` 文件夹中将依次生成原始 ONNX 文件 `yolo11n-cls.onnx` 和转换后的 `yolo11n-cls-trtyolo.onnx`。接下来，使用 `trtexec` 工具将转换后的 ONNX 文件构建为 TensorRT 引擎（fp16）：
 
 ```bash
-trtexec --onnx=models/yolo11n-cls.onnx --saveEngine=models/yolo11n-cls.engine --fp16
+trtexec --onnx=models/yolo11n-cls-trtyolo.onnx --saveEngine=models/yolo11n-cls.engine --fp16
 ```
 
 ## 模型推理

--- a/examples/detect/README.en.md
+++ b/examples/detect/README.en.md
@@ -8,22 +8,23 @@ This example uses the yolo11n model to demonstrate how to perform Object Detecti
 
 Please download the required `yolo11n.pt` model file and test images through the provided link, and save the model file to the `models` folder, and place the extracted test images into the `images` folder after unzipping.
 
-## Model Export
+## Model Convert
 
 > [!IMPORTANT]
 >
-> Use the [`trtyolo-export`](https://github.com/laugh12321/TensorRT-YOLO/tree/export) tool package that comes with the project to export the ONNX model suitable for inference in this project and build it into a TensorRT engine.
+> Please first export the model weights to ONNX, then use the bundled [`trtyolo-export`](https://github.com/laugh12321/trtyolo-export) tool to convert the ONNX model into TensorRT-YOLO compatible outputs and build it into a TensorRT engine.
 
-Use the following command to export the ONNX format with the [EfficientNMS](https://github.com/NVIDIA/TensorRT/tree/main/plugin/efficientNMSPlugin) plugin:
+Use the following commands to export ONNX first and then convert it into the structure required by this project. The converted ONNX will automatically integrate the [EfficientNMS](https://github.com/NVIDIA/TensorRT/tree/main/plugin/efficientNMSPlugin) plugin:
 
 ```bash
-trtyolo export -w models/yolo11n.pt -v yolo11 -o models -s
+yolo export model=models/yolo11n.pt format=onnx batch=1
+trtyolo-export -i models/yolo11n.onnx -o models/yolo11n-trtyolo.onnx -s
 ```
 
-After running the above command, a `yolo11n.onnx` file with a `batch_size` of 1 will be generated in the `models` folder. Next, use the `trtexec` tool to convert the ONNX file to a TensorRT engine (fp16):
+After running the commands above, the `models` folder will contain the original ONNX file `yolo11n.onnx` and the converted file `yolo11n-trtyolo.onnx`. Next, use `trtexec` to build a TensorRT engine from the converted ONNX file (fp16):
 
 ```bash
-trtexec --onnx=models/yolo11n.onnx --saveEngine=models/yolo11n.engine --fp16
+trtexec --onnx=models/yolo11n-trtyolo.onnx --saveEngine=models/yolo11n.engine --fp16
 ```
 
 ## Model Inference

--- a/examples/detect/README.md
+++ b/examples/detect/README.md
@@ -8,22 +8,23 @@
 
 请通过提供的链接下载所需的 `yolo11n.pt` 模型文件和测试图片，并将模型文件保存至 `models` 文件夹，测试图片解压后存放至 `images` 文件夹。
 
-## 模型导出
+## 模型转换
 
 > [!IMPORTANT]
 >
-> 使用项目配套的 [`trtyolo-export`](https://github.com/laugh12321/TensorRT-YOLO/tree/export) 工具包，导出适用于该项目推理的 ONNX 模型并构建为 TensorRT 引擎。
+> 请先将模型权重导出为 ONNX，再使用项目配套的 [`trtyolo-export`](https://github.com/laugh12321/trtyolo-export) 工具包，将 ONNX 模型转换为兼容 TensorRT-YOLO 推理的输出结构并构建为 TensorRT 引擎。
 
-使用以下命令导出带 [EfficientNMS](https://github.com/NVIDIA/TensorRT/tree/main/plugin/efficientNMSPlugin) 插件的 ONNX 格式：
+使用以下命令先导出 ONNX，再转换为适用于该项目推理的模型结构。转换后的 ONNX 会自动集成 [EfficientNMS](https://github.com/NVIDIA/TensorRT/tree/main/plugin/efficientNMSPlugin) 插件：
 
 ```bash
-trtyolo export -w models/yolo11n.pt -v yolo11 -o models -s
+yolo export model=models/yolo11n.pt format=onnx batch=1
+trtyolo-export -i models/yolo11n.onnx -o models/yolo11n-trtyolo.onnx -s
 ```
 
-运行上述命令后，`models` 文件夹中将生成一个 `batch_size` 为 1 的 `yolo11n.onnx` 文件。接下来，使用 `trtexec` 工具将 ONNX 文件转换为 TensorRT 引擎（fp16）：
+运行上述命令后，`models` 文件夹中将依次生成原始 ONNX 文件 `yolo11n.onnx` 和转换后的 `yolo11n-trtyolo.onnx`。接下来，使用 `trtexec` 工具将转换后的 ONNX 文件构建为 TensorRT 引擎（fp16）：
 
 ```bash
-trtexec --onnx=models/yolo11n.onnx --saveEngine=models/yolo11n.engine --fp16
+trtexec --onnx=models/yolo11n-trtyolo.onnx --saveEngine=models/yolo11n.engine --fp16
 ```
 
 ## 模型推理

--- a/examples/mutli_thread/README.en.md
+++ b/examples/mutli_thread/README.en.md
@@ -25,7 +25,7 @@ import supervision as sv
 from trtyolo import TRTYOLO
 
 # -------------------- Initialize the model --------------------
-# Note: The task parameter must match the task type specified during export ("detect", "segment", "classify", "pose", "obb")
+# Note: The task parameter must match the task type of the exported ONNX model ("detect", "segment", "classify", "pose", "obb")
 # The profile parameter, when enabled, calculates performance metrics during inference, which can be retrieved by calling model.profile()
 # The swap_rb parameter, when enabled, swaps the channel order before inference (ensuring the model input is RGB)
 model = TRTYOLO("yolo11n-with-plugin.engine", task="detect", profile=True, swap_rb=True)

--- a/examples/mutli_thread/README.md
+++ b/examples/mutli_thread/README.md
@@ -25,7 +25,7 @@ import supervision as sv
 from trtyolo import TRTYOLO
 
 # -------------------- 初始化模型 --------------------
-# 注意：task参数需与导出时指定的任务类型一致（"detect"、"segment"、"classify"、"pose"、"obb"）
+# 注意：task参数需与导出为 ONNX 时的任务类型一致（"detect"、"segment"、"classify"、"pose"、"obb"）
 # profile参数开启后，会在推理时计算性能指标，调用 model.profile() 可获取
 # swap_rb参数开启后，会在推理前交换通道顺序（确保模型输入时RGB）
 model = TRTYOLO("yolo11n-with-plugin.engine", task="detect", profile=True, swap_rb=True)

--- a/examples/nndeploy/README.en.md
+++ b/examples/nndeploy/README.en.md
@@ -21,7 +21,7 @@ Refer to the [TensorRT-YOLO Quick Compilation and Installation](https://github.c
 
 ## 2. Model Conversion
 
-Refer to the methods in [TensorRT-YOLO Model Export](https://github.com/laugh12321/TensorRT-YOLO/blob/main/docs/en/model_export.md). First, export the model to ONNX format using the command-line tool (CLI) of the model's Python library, then convert the ONNX model to a TensorRT engine.
+Refer to [Ultralytics YOLO model export](https://docs.ultralytics.com/modes/export/) and [`trtyolo-export`](https://github.com/laugh12321/trtyolo-export). First, export the model to ONNX format with the model's Python library CLI, then use `trtyolo-export` to convert the ONNX model into TensorRT-YOLO compatible outputs, and finally build it into a TensorRT engine.
 
 ## 3. Adding Custom Nodes
 

--- a/examples/nndeploy/README.md
+++ b/examples/nndeploy/README.md
@@ -21,7 +21,7 @@
 
 ## 2. 模型转换
 
-参考 [TensorRT-YOLO 模型导出](https://github.com/laugh12321/TensorRT-YOLO/blob/main/docs/cn/model_export.md) 中的方法，先通过模型 Python 库的命令行工具（CLI）将模型导出为 ONNX 格式，再将 ONNX 模型转换为 TensorRT 引擎。
+参考 [Ultralytics YOLO 模型导出](https://docs.ultralytics.com/zh/modes/export/) 与 [`trtyolo-export`](https://github.com/laugh12321/trtyolo-export) 中的方法，先将模型权重导出为 ONNX 格式，再使用 `trtyolo-export` 将 ONNX 模型转换为兼容 TensorRT-YOLO 推理的输出结构，最后构建为 TensorRT 引擎。
 
 ## 3. 添加自定义节点
 

--- a/examples/obb/README.en.md
+++ b/examples/obb/README.en.md
@@ -1,31 +1,30 @@
 [简体中文](README.md) | English
 
-# Oriented Bounding Boxes Object Detection Inference Example
+# Oriented Bounding Box Detection Inference Example
 
-This example uses the YOLO11n-obb model to demonstrate how to perform Oriented Bounding Boxes Object Detection inference using the Command Line Interface (CLI), Python, and C++.
-
-The required `yolo11n-obb.pt` and test images are provided and saved in the `images` folder and `models` folder, respectively.
+This example uses the YOLO11n-obb model to demonstrate how to perform oriented bounding box detection inference using the Command Line Interface (CLI), Python, and C++.
 
 [yolo11n-obb.pt](https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n-obb.pt)，[【TestImages】DOTA-part.zip](https://www.ilanzou.com/s/yK6yq8H5)
 
 Please download the required `yolo11n-obb.pt` model file and test images through the provided link, and save the model file to the `models` folder, and place the extracted test images into the `images` folder after unzipping.
 
-## Model Export
+## Model Convert
 
 > [!IMPORTANT]
 >
-> Use the [`trtyolo-export`](https://github.com/laugh12321/TensorRT-YOLO/tree/export) tool package that comes with the project to export the ONNX model suitable for inference in this project and build it into a TensorRT engine.
+> Please first export the model weights to ONNX, then use the bundled [`trtyolo-export`](https://github.com/laugh12321/trtyolo-export) tool to convert the ONNX model into TensorRT-YOLO compatible outputs and build it into a TensorRT engine.
 
-Use the following command to export the ONNX format with the [EfficientRotatedNMS](../../modules/plugin/efficientRotatedNMSPlugin/) plugin:
+Use the following commands to export ONNX first and then convert it into the structure required by this project. The converted ONNX will automatically integrate the [EfficientRotatedNMS](../../modules/plugin/efficientRotatedNMSPlugin/) plugin:
 
 ```bash
-trtyolo export -w models/yolo11n-obb.pt -v yolo11 -o models -s
+yolo export model=models/yolo11n-obb.pt format=onnx batch=1
+trtyolo-export -i models/yolo11n-obb.onnx -o models/yolo11n-obb-trtyolo.onnx -s
 ```
 
-After running the above command, a `yolo11n-obb.onnx` file with a `batch_size` of 1 will be generated in the `models` folder. Next, use the `trtexec` tool to convert the ONNX file to a TensorRT engine (fp16):
+After running the commands above, the `models` folder will contain the original ONNX file `yolo11n-obb.onnx` and the converted file `yolo11n-obb-trtyolo.onnx`. Next, use `trtexec` to build a TensorRT engine from the converted ONNX file (fp16):
 
 ```bash
-trtexec --onnx=models/yolo11n-obb.onnx --saveEngine=models/yolo11n-obb.engine --fp16 --staticPlugins=/your/tensorrt-yolo/install/dir/lib/libcustom_plugins.so --setPluginsToSerialize=/your/tensorrt-yolo/install/dir/lib/libcustom_plugins.so
+trtexec --onnx=models/yolo11n-obb-trtyolo.onnx --saveEngine=models/yolo11n-obb.engine --fp16 --staticPlugins=/your/tensorrt-yolo/install/dir/lib/libcustom_plugins.so --setPluginsToSerialize=/your/tensorrt-yolo/install/dir/lib/libcustom_plugins.so
 ```
 
 ## Model Inference

--- a/examples/obb/README.md
+++ b/examples/obb/README.md
@@ -8,22 +8,23 @@
 
 请通过提供的链接下载所需的 `yolo11n-obb.pt` 模型文件和测试图片，并将模型文件保存至 `models` 文件夹，测试图片解压后存放至 `images` 文件夹。
 
-## 模型导出
+## 模型转换
 
 > [!IMPORTANT]
 >
-> 使用项目配套的 [`trtyolo-export`](https://github.com/laugh12321/TensorRT-YOLO/tree/export) 工具包，导出适用于该项目推理的 ONNX 模型并构建为 TensorRT 引擎。
+> 请先将模型权重导出为 ONNX，再使用项目配套的 [`trtyolo-export`](https://github.com/laugh12321/trtyolo-export) 工具包，将 ONNX 模型转换为兼容 TensorRT-YOLO 推理的输出结构并构建为 TensorRT 引擎。
 
-使用以下命令导出带 [EfficientRotatedNMS](../../modules/plugin/efficientRotatedNMSPlugin/)  插件的 ONNX 格式模型：
+使用以下命令先导出 ONNX，再转换为适用于该项目推理的模型结构。转换后的 ONNX 会自动集成 [EfficientRotatedNMS](../../modules/plugin/efficientRotatedNMSPlugin/) 插件：
 
 ```bash
-trtyolo export -w models/yolo11n-obb.pt -v yolo11 -o models -s
+yolo export model=models/yolo11n-obb.pt format=onnx batch=1
+trtyolo-export -i models/yolo11n-obb.onnx -o models/yolo11n-obb-trtyolo.onnx -s
 ```
 
-运行上述命令后，`models` 文件夹中将生成一个 `batch_size` 为 1 的 `yolo11n-obb.onnx` 文件。接下来，使用 `trtexec` 工具将 ONNX 文件转换为 TensorRT 引擎（fp16）：
+运行上述命令后，`models` 文件夹中将依次生成原始 ONNX 文件 `yolo11n-obb.onnx` 和转换后的 `yolo11n-obb-trtyolo.onnx`。接下来，使用 `trtexec` 工具将转换后的 ONNX 文件构建为 TensorRT 引擎（fp16）：
 
 ```bash
-trtexec --onnx=models/yolo11n-obb.onnx --saveEngine=models/yolo11n-obb.engine --fp16 --staticPlugins=/your/tensorrt-yolo/install/dir/lib/libcustom_plugins.so --setPluginsToSerialize=/your/tensorrt-yolo/install/dir/lib/libcustom_plugins.so
+trtexec --onnx=models/yolo11n-obb-trtyolo.onnx --saveEngine=models/yolo11n-obb.engine --fp16 --staticPlugins=/your/tensorrt-yolo/install/dir/lib/libcustom_plugins.so --setPluginsToSerialize=/your/tensorrt-yolo/install/dir/lib/libcustom_plugins.so
 ```
 
 ## 模型推理

--- a/examples/pose/README.en.md
+++ b/examples/pose/README.en.md
@@ -8,22 +8,23 @@ This example uses the yolo11n-pose model to demonstrate how to perform pose esti
 
 Please download the required `yolo11n-pose.pt` model file and test images through the provided link, and save the model file to the `models` folder, and place the extracted test images into the `images` folder after unzipping.
 
-## Model Export
+## Model Convert
 
 > [!IMPORTANT]
 >
-> Use the [`trtyolo-export`](https://github.com/laugh12321/TensorRT-YOLO/tree/export) tool package that comes with the project to export the ONNX model suitable for inference in this project and build it into a TensorRT engine.
+> Please first export the model weights to ONNX, then use the bundled [`trtyolo-export`](https://github.com/laugh12321/trtyolo-export) tool to convert the ONNX model into TensorRT-YOLO compatible outputs and build it into a TensorRT engine.
 
-Use the following command to export the ONNX format with the [EfficientIdxNMS](../../modules/plugin/efficientIdxNMSPlugin/) plugin:
+Use the following commands to export ONNX first and then convert it into the structure required by this project. The converted ONNX will automatically integrate the [EfficientIdxNMS](../../modules/plugin/efficientIdxNMSPlugin/) plugin:
 
 ```bash
-trtyolo export -w models/yolo11n-pose.pt -v yolo11 -o models -s
+yolo export model=models/yolo11n-pose.pt format=onnx batch=1
+trtyolo-export -i models/yolo11n-pose.onnx -o models/yolo11n-pose-trtyolo.onnx -s
 ```
 
-After running the above command, a `yolo11n-pose.onnx` file with a `batch_size` of 1 will be generated in the `models` folder. Next, use the `trtexec` tool to convert the ONNX file to a TensorRT engine (fp16):
+After running the commands above, the `models` folder will contain the original ONNX file `yolo11n-pose.onnx` and the converted file `yolo11n-pose-trtyolo.onnx`. Next, use `trtexec` to build a TensorRT engine from the converted ONNX file (fp16):
 
 ```bash
-trtexec --onnx=models/yolo11n-pose.onnx --saveEngine=models/yolo11n-pose.engine --fp16 --staticPlugins=/your/tensorrt-yolo/install/dir/lib/libcustom_plugins.so --setPluginsToSerialize=/your/tensorrt-yolo/install/dir/lib/libcustom_plugins.so
+trtexec --onnx=models/yolo11n-pose-trtyolo.onnx --saveEngine=models/yolo11n-pose.engine --fp16 --staticPlugins=/your/tensorrt-yolo/install/dir/lib/libcustom_plugins.so --setPluginsToSerialize=/your/tensorrt-yolo/install/dir/lib/libcustom_plugins.so
 ```
 
 ## Model Inference

--- a/examples/pose/README.md
+++ b/examples/pose/README.md
@@ -8,22 +8,23 @@
 
 请通过提供的链接下载所需的 `yolo11n-pose.pt` 模型文件和测试图片，并将模型文件保存至 `models` 文件夹，测试图片解压后存放至 `images` 文件夹。
 
-## 模型导出
+## 模型转换
 
 > [!IMPORTANT]
 >
-> 使用项目配套的 [`trtyolo-export`](https://github.com/laugh12321/TensorRT-YOLO/tree/export) 工具包，导出适用于该项目推理的 ONNX 模型并构建为 TensorRT 引擎。
+> 请先将模型权重导出为 ONNX，再使用项目配套的 [`trtyolo-export`](https://github.com/laugh12321/trtyolo-export) 工具包，将 ONNX 模型转换为兼容 TensorRT-YOLO 推理的输出结构并构建为 TensorRT 引擎。
 
-使用以下命令导出带 [EfficientIdxNMS](../../modules/plugin/efficientIdxNMSPlugin/)  插件的 ONNX 格式：
+使用以下命令先导出 ONNX，再转换为适用于该项目推理的模型结构。转换后的 ONNX 会自动集成 [EfficientIdxNMS](../../modules/plugin/efficientIdxNMSPlugin/) 插件：
 
 ```bash
-trtyolo export -w models/yolo11n-pose.pt -v yolo11 -o models -s
+yolo export model=models/yolo11n-pose.pt format=onnx batch=1
+trtyolo-export -i models/yolo11n-pose.onnx -o models/yolo11n-pose-trtyolo.onnx -s
 ```
 
-运行上述命令后，`models` 文件夹中将生成一个 `batch_size` 为 1 的 `yolo11n-pose.onnx` 文件。接下来，使用 `trtexec` 工具将 ONNX 文件转换为 TensorRT 引擎（fp16）：
+运行上述命令后，`models` 文件夹中将依次生成原始 ONNX 文件 `yolo11n-pose.onnx` 和转换后的 `yolo11n-pose-trtyolo.onnx`。接下来，使用 `trtexec` 工具将转换后的 ONNX 文件构建为 TensorRT 引擎（fp16）：
 
 ```bash
-trtexec --onnx=models/yolo11n-pose.onnx --saveEngine=models/yolo11n-pose.engine --fp16 --staticPlugins=/your/tensorrt-yolo/install/dir/lib/libcustom_plugins.so --setPluginsToSerialize=/your/tensorrt-yolo/install/dir/lib/libcustom_plugins.so
+trtexec --onnx=models/yolo11n-pose-trtyolo.onnx --saveEngine=models/yolo11n-pose.engine --fp16 --staticPlugins=/your/tensorrt-yolo/install/dir/lib/libcustom_plugins.so --setPluginsToSerialize=/your/tensorrt-yolo/install/dir/lib/libcustom_plugins.so
 ```
 
 ## 模型推理

--- a/examples/segment/README.en.md
+++ b/examples/segment/README.en.md
@@ -8,22 +8,23 @@ This example uses the YOLO11n-seg model to demonstrate how to perform Instance S
 
 Please download the required `yolo11n-seg.pt` model file and test images through the provided link, and save the model file to the `models` folder, and place the extracted test images into the `images` folder after unzipping.
 
-## Model Export
+## Model Convert
 
 > [!IMPORTANT]
 >
-> Use the [`trtyolo-export`](https://github.com/laugh12321/TensorRT-YOLO/tree/export) tool package that comes with the project to export the ONNX model suitable for inference in this project and build it into a TensorRT engine.
+> Please first export the model weights to ONNX, then use the bundled [`trtyolo-export`](https://github.com/laugh12321/trtyolo-export) tool to convert the ONNX model into TensorRT-YOLO compatible outputs and build it into a TensorRT engine.
 
-Use the following command to export the ONNX format with the [EfficientIdxNMS](../../modules/plugin/efficientIdxNMSPlugin/) plugin:
+Use the following commands to export ONNX first and then convert it into the structure required by this project. The converted ONNX will automatically integrate the [EfficientIdxNMS](../../modules/plugin/efficientIdxNMSPlugin/) plugin:
 
 ```bash
-trtyolo export -w models/yolo11n-seg.pt -v yolo11 -o models -s
+yolo export model=models/yolo11n-seg.pt format=onnx batch=1
+trtyolo-export -i models/yolo11n-seg.onnx -o models/yolo11n-seg-trtyolo.onnx -s
 ```
 
-After running the above command, a `yolo11n-seg.onnx` file with a `batch_size` of 1 will be generated in the `models` folder. Next, use the `trtexec` tool to convert the ONNX file to a TensorRT engine (fp16):
+After running the commands above, the `models` folder will contain the original ONNX file `yolo11n-seg.onnx` and the converted file `yolo11n-seg-trtyolo.onnx`. Next, use `trtexec` to build a TensorRT engine from the converted ONNX file (fp16):
 
 ```bash
-trtexec --onnx=models/yolo11n-seg.onnx --saveEngine=models/yolo11n-seg.engine --fp16 --staticPlugins=/your/tensorrt-yolo/install/dir/lib/libcustom_plugins.so --setPluginsToSerialize=/your/tensorrt-yolo/install/dir/lib/libcustom_plugins.so
+trtexec --onnx=models/yolo11n-seg-trtyolo.onnx --saveEngine=models/yolo11n-seg.engine --fp16 --staticPlugins=/your/tensorrt-yolo/install/dir/lib/libcustom_plugins.so --setPluginsToSerialize=/your/tensorrt-yolo/install/dir/lib/libcustom_plugins.so
 ```
 
 ## Model Inference

--- a/examples/segment/README.md
+++ b/examples/segment/README.md
@@ -8,22 +8,23 @@
 
 请通过提供的链接下载所需的 `yolo11n-seg.pt` 模型文件和测试图片，并将模型文件保存至 `models` 文件夹，测试图片解压后存放至 `images` 文件夹。
 
-## 模型导出
+## 模型转换
 
 > [!IMPORTANT]
 >
-> 使用项目配套的 [`trtyolo-export`](https://github.com/laugh12321/TensorRT-YOLO/tree/export) 工具包，导出适用于该项目推理的 ONNX 模型并构建为 TensorRT 引擎。
+> 请先将模型权重导出为 ONNX，再使用项目配套的 [`trtyolo-export`](https://github.com/laugh12321/trtyolo-export) 工具包，将 ONNX 模型转换为兼容 TensorRT-YOLO 推理的输出结构并构建为 TensorRT 引擎。
 
-使用以下命令导出带 [EfficientIdxNMS](../../modules/plugin/efficientIdxNMSPlugin/)  插件的 ONNX 格式：
+使用以下命令先导出 ONNX，再转换为适用于该项目推理的模型结构。转换后的 ONNX 会自动集成 [EfficientIdxNMS](../../modules/plugin/efficientIdxNMSPlugin/) 插件：
 
 ```bash
-trtyolo export -w models/yolo11n-seg.pt -v yolo11 -o models -s
+yolo export model=models/yolo11n-seg.pt format=onnx batch=1
+trtyolo-export -i models/yolo11n-seg.onnx -o models/yolo11n-seg-trtyolo.onnx -s
 ```
 
-运行上述命令后，`models` 文件夹中将生成一个 `batch_size` 为 1 的 `yolo11n-seg.onnx` 文件。接下来，使用 `trtexec` 工具将 ONNX 文件转换为 TensorRT 引擎（fp16）：
+运行上述命令后，`models` 文件夹中将依次生成原始 ONNX 文件 `yolo11n-seg.onnx` 和转换后的 `yolo11n-seg-trtyolo.onnx`。接下来，使用 `trtexec` 工具将转换后的 ONNX 文件构建为 TensorRT 引擎（fp16）：
 
 ```bash
-trtexec --onnx=models/yolo11n-seg.onnx --saveEngine=models/yolo11n-seg.engine --fp16 --staticPlugins=/your/tensorrt-yolo/install/dir/lib/libcustom_plugins.so --setPluginsToSerialize=/your/tensorrt-yolo/install/dir/lib/libcustom_plugins.so
+trtexec --onnx=models/yolo11n-seg-trtyolo.onnx --saveEngine=models/yolo11n-seg.engine --fp16 --staticPlugins=/your/tensorrt-yolo/install/dir/lib/libcustom_plugins.so --setPluginsToSerialize=/your/tensorrt-yolo/install/dir/lib/libcustom_plugins.so
 ```
 
 ## 模型推理


### PR DESCRIPTION
## Summary by Sourcery

Update example READMEs to reflect the new two-step model ONNX export and TensorRT-YOLO conversion workflow.

Documentation:
- Refresh example READMEs for detect, segment, pose, OBB, classify, VideoPipe, multi-thread, and nndeploy to document exporting with Ultralytics YOLO then converting with trtyolo-export into TensorRT engines.
- Clarify plugin integration (EfficientNMS, EfficientIdxNMS, EfficientRotatedNMS) and the specific ONNX files used when building TensorRT engines in all examples.
- Fix wording, headings, and minor typos in English and Chinese documentation, including aligning terminology like model conversion and workspace paths.